### PR TITLE
Add AppContext to export

### DIFF
--- a/src/src/context/Context.js
+++ b/src/src/context/Context.js
@@ -306,4 +306,4 @@ const Connect = (Component) => (
   )
 )
 
-export { Provider, Connect }
+export { AppContext, Provider, Connect }


### PR DESCRIPTION
Use `useContext` from now on instead of `Context.Consumer`.
It fix later that the `Context.Consumer` that use up to now.